### PR TITLE
More flexible MIME/codec native support detection

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -440,8 +440,10 @@
 			this.flash.canPlay = {};
 			$.each(this.formats, function(priority, format) {
 				var codecAvailable = false;
-				for (var i = 0; i < self.format[format].codec.length; i++)
-					codecAvailable |= self.htmlElement[self.format[format].media].canPlayType(self.format[format].codec[i]) !== "";
+				for (var i = 0; i < self.format[format].codec.length; i++) {
+					var cur_elem = self.htmlElement[self.format[format].media];
+					codecAvailable |= cur_elem.canPlayType !== undefined && cur_elem.canPlayType(self.format[format].codec[i]) !== "";
+				}
 				self.html.canPlay[format] = self.html[self.format[format].media].available && codecAvailable;
 				self.flash.canPlay[format] = self.format[format].flashCanPlay && self.flash.available;
 			});


### PR DESCRIPTION
Hi,

First of all I'd like to say a big thanks for this nice piece of code. Great job!

I was looking for a simple and straightforward player for a minimalist inline music player and jPlayer is a perfect match. I love the idea of first checking the native browser support for the given resource and just then falling over to flash player. I was very surprised, though, when an embedded AAC file was played back using flash backend on the latest Safari (come on, Apple doesn't support AAC?!). After some investigation I found the culprit: canPlayType method of <audio> tag. It returned false when passed 'audio/mp4; codecs="mp4a.40.2"', but _didn't_ when passed 'audio/x-m4a' (without any specific codec!).

The idea that came to my mind is quite obvious - it's simply wrong to map a container to a mime/codec pair, since while we usually control one end (the source of media) we don't the other (user's environment), which may vary significantly, yet still enable a user to use the native support.

My change is just adding support for specifying more than one valid mime/codec pair per container. Currently I just added one more case where mime types differ, but I can imagine situation when codecs vary.

If you consider it valuable please just pull it from my repo.

Have a nice day,
Michal
