### PR TITLE
jslint.org and $ -> jQuery

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -7,7 +7,7 @@
  *  - http://www.opensource.org/licenses/mit-license.php
  *  - http://www.gnu.org/copyleft/gpl.html
  *
- * Author: Mark J Panaghiston
+ * Author: Mark J Panaghiston, Georgi Momchilov
  * Version: 2.0.5
  * Date: 4th March 2011
  */


### PR DESCRIPTION
Hello there,

I came across your jPlayer plugin recently - job well done!

Unfortunately, it couldn't be packed (using javascriptcompressor.com, for example) - a packed version rendered the plugin unusable as errors were thrown in the browser. So, I ran the .js file through jslint.org and fixed some issues - it works like a charm now, even if packed (packed size is ~21k down from ~86k; minified is ~32k).

I also replaced $ with jQuery to make the script consistent with jQuery.noConflict();

regards,
Georgi
