### PR TITLE
jplayer.playlist to work with jquery sortable

### DIFF
--- a/add-on/jplayer.playlist.js
+++ b/add-on/jplayer.playlist.js
@@ -456,12 +456,14 @@
 		},
         scan: function() {
             var self = this;
+            var isAdjusted = false;
 
             var replace = [];
             $.each($(this.cssSelector.playlist + " ul li"), function(index, value) {
                 replace[index] = self.original[$(value).attr('name')];
-                if(self.current === parseInt($(value).attr('name'), 10)) {
+                if(!isAdjusted && self.current === parseInt($(value).attr('name'), 10)) {
                     self.current = index;
+                    isAdjusted = true;
                 }
                 $(value).attr('name', index);
             });


### PR DESCRIPTION
Hi,

one interesting thing would be allowing users to sort the tracks on the playlist. I changed the jplayer.playlist.js to enable it to work together with jQuery Sortable. This way, users can drag and drop items from the playlist to change it's order.

I also submitted the code to jshint, there is no erros.
