### PR TITLE
Added a callback option so that custom code can be executed once the playlist plugin has finished initialisation

### DIFF
--- a/add-on/jplayer.playlist.js
+++ b/add-on/jplayer.playlist.js
@@ -129,7 +129,8 @@
 				itemClass: "jp-playlist-item",
 				freeGroupClass: "jp-free-media",
 				freeItemClass: "jp-playlist-item-free",
-				removeItemClass: "jp-playlist-item-remove"
+				removeItemClass: "jp-playlist-item-remove",
+				readyCallback : null
 			}
 		},
 		option: function(option, value) { // For changing playlist options only
@@ -160,6 +161,9 @@
 					self.play(self.current);
 				} else {
 					self.select(self.current);
+				}
+				if(typeof self.options.readyCallback == 'function') {
+					self.options.readyCallback.call(this);
 				}
 			});
 		},


### PR DESCRIPTION
I needed to be able to add custom content to each item row in the playlist, yet no suitable event / callback options were available.
