### PR TITLE
Fix for IE bug when using tabkey to access the player/document

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -693,7 +693,7 @@
 				// Non IE browsers have an initial Flash size of 1 by 1 otherwise the wmode affected the Flash ready event. 
 
 				if($.browser.msie && Number($.browser.version) <= 8) {
-					var objStr = '<object id="' + this.internal.flash.id + '" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="0" height="0"></object>';
+					var objStr = '<object id="' + this.internal.flash.id + '" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="0" height="0" tabindex="-1"></object>';
 
 					var paramStr = [
 						'<param name="movie" value="' + this.internal.flash.swf + '" />',
@@ -721,6 +721,7 @@
 					htmlObj.setAttribute("type", "application/x-shockwave-flash");
 					htmlObj.setAttribute("width", "1"); // Non-zero
 					htmlObj.setAttribute("height", "1"); // Non-zero
+					htmlObj.setAttribute("tabindex", "-1"); // Remove tabindex to fix IE Bug
 					createParam(htmlObj, "flashvars", flashVars);
 					createParam(htmlObj, "allowscriptaccess", "always");
 					createParam(htmlObj, "bgcolor", this.options.backgroundColor);


### PR DESCRIPTION
The flash seems to destroy the tab key access of the document in Internet Explorer. When I tab through my links, the focus jumps to the address bar after I tab over the object tag. After this, the whole document can not be accessed again.

Adding `tabindex="-1"` to the object tag solves this problem.
