### PR TITLE
Configurable separate urls for html and flash solution

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -1281,6 +1281,10 @@
 					if(self[solution].support[format] && self._validString(media[format])) { // Format supported in solution and url given for format.
 						var isHtml = solution === 'html';
 
+                                                // if media url contains comma separated urls, then use first one for html and second for flash
+						if( media[format].indexOf( "," ) > 0 )
+							media[format] = media[format].split( ',' )[ isHtml ? 1 : 0 ];
+
 						if(isVideo) {
 							if(isHtml) {
 								self.html.video.gate = true;


### PR DESCRIPTION
Now you can set media URL as comma separated list string of two URLs. First one is used for HTML solution and other one for flash fallback. This way let you safetly use relative urls for media.
