### PR TITLE
Small fix to allow jquery objects in cssSelectorAncestor in addition to selector string.

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -95,6 +95,7 @@
 		click: "jPlayer_click", // Occurs when the user clicks on one of the following: poster image, html video, flash video.
 		error: "jPlayer_error", // Event error code in event.jPlayer.error.type. See $.jPlayer.error
 		warning: "jPlayer_warning", // Event warning code in event.jPlayer.warning.type. See $.jPlayer.warning
+		playclicked: "jPlayer_playclicked", // Occurs right after the user clicks on the play button
 
 		// Other events match HTML5 spec.
 		loadstart: "jPlayer_loadstart",
@@ -1387,6 +1388,7 @@
 			}
 		},
 		play: function(time) {
+			this._trigger($.jPlayer.event.playclicked);
 			time = (typeof time === "number") ? time : NaN; // Remove jQuery event from click handler
 			if(this.status.srcSet) {
 				if(this.html.active) {

--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -475,7 +475,6 @@
 			this.flash = {}; // In _init()'s this.desired code and setmedia(): Accessed via this[solution], where solution from this.solutions array.
 			
 			this.css = {};
-			this.css.cs = {}; // Holds the css selector strings
 			this.css.jq = {}; // Holds jQuery selectors. ie., $(css.cs.method)
 
 			this.ancestorJq = []; // Holds jQuery selector of cssSelectorAncestor. Init would use $() instead of [], but it is only 1.4+
@@ -1587,10 +1586,9 @@
 						this.css.jq[fn].unbind(".jPlayer");
 					}
 					this.options.cssSelector[fn] = cssSel;
-					this.css.cs[fn] = this.options.cssSelectorAncestor + " " + cssSel;
 
 					if(cssSel) { // Checks for empty string
-						this.css.jq[fn] = $(this.css.cs[fn]);
+						this.css.jq[fn] = this.ancestorJq.find(cssSel);
 					} else {
 						this.css.jq[fn] = []; // To comply with the css.jq[fn].length check before its use. As of jQuery 1.4 could have used $() for an empty set. 
 					}
@@ -1607,7 +1605,7 @@
 					if(cssSel && this.css.jq[fn].length !== 1) { // So empty strings do not generate the warning. ie., they just remove the old one.
 						this._warning( {
 							type: $.jPlayer.warning.CSS_SELECTOR_COUNT,
-							context: this.css.cs[fn],
+							context: this.css.jq[fn].selector,
 							message: $.jPlayer.warningMsg.CSS_SELECTOR_COUNT + this.css.jq[fn].length + " found for " + fn + " method.",
 							hint: $.jPlayer.warningHint.CSS_SELECTOR_COUNT
 						});


### PR DESCRIPTION
[FIX] With this little fix you can set your cssSelectorAncestor as a jQuery object. This is also backward compatible with string selectors.
