### PR TITLE
MS IE9 reports html5 support for M4A but then fails

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -644,7 +644,12 @@
 			this.html.canPlay = {};
 			this.flash.canPlay = {};
 			$.each(this.formats, function(priority, format) {
-				self.html.canPlay[format] = self.html[self.format[format].media].available && "" !== self.htmlElement[self.format[format].media].canPlayType(self.format[format].codec);
+                var browserCanPlay = self.html[self.format[format].media].available && "" !== self.htmlElement[self.format[format].media].canPlayType(self.format[format].codec);
+                // Override this if MS IE 9 and M4A which is falsely reported as supported
+                if (format == 'm4a' && $.jPlayer.browser.msie && Number($.jPlayer.browser.version) == 9) {
+                    browserCanPlay = false;
+                }
+                self.html.canPlay[format] = browserCanPlay;
 				self.flash.canPlay[format] = self.format[format].flashCanPlay && self.flash.available;
 			});
 			this.html.desired = false;


### PR DESCRIPTION
This fix works around the known issue in MSIE 9 where M4A files are reported as supported by the browser but calling setMedia fails.

I added code to detect M4a and MSIE9 and force the canPlay flag to false in this case, so flash kicks in if it is one of your solutions.
