### PR TITLE
Add opus codec for ogg, add flac

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -447,7 +447,12 @@
 				media: 'audio'
 			},
 			oga: { // OGG
-				codec: 'audio/ogg; codecs="vorbis"',
+				codec: 'audio/ogg; codecs="vorbis, opus"',
+				flashCanPlay: false,
+				media: 'audio'
+			},
+			flac: { // FLAC
+				codec: 'audio/x-flac',
 				flashCanPlay: false,
 				media: 'audio'
 			},


### PR DESCRIPTION
official mime type for opus is audio/ogg, codec=opus
flac native bitstream is unregistered and uses x-flac
