### PR TITLE
 Use allowInsecureDomain in order to support serving the SWF over HTTPS. 

### DIFF
--- a/actionscript/Jplayer.as
+++ b/actionscript/Jplayer.as
@@ -81,6 +81,7 @@ package {
 		public function Jplayer() {
 
 			flash.system.Security.allowDomain("*");
+			flash.system.Security.allowInsecureDomain("*");
 			traceOut = new TraceOut();
 
 			// Fix to the security exploit reported by Jason Calvert http://appsec.ws/


### PR DESCRIPTION
If the webpage is served over HTTP and the SWF is served over HTTPS, then jPlayer does not function. We need to call flash.system.Security.allowInsecureDomain("*") in order to fix it.
