### PR TITLE
m3u8 support 

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -702,6 +702,11 @@
 				flashCanPlay: true,
 				media: 'video'
 			},
+			m3u8: { // H.264 / MP4 / Apple HLS
+				codec: 'application/vnd.apple.mpegurl; codecs="avc1.42E01E, mp4a.40.2"',
+				flashCanPlay: false,
+				media: 'video'
+			},
 			ogv: { // OGG
 				codec: 'video/ogg; codecs="theora, vorbis"',
 				flashCanPlay: false,


### PR DESCRIPTION
m3u8 support for iPad and iPhone is a pretty useful feature for streaming live video with native support. Also listed here: https://groups.google.com/d/topic/jplayer/1b0SZQf2Oh0/discussion

This could be done as simple as adding the format to the list as it basically an container format of distribution of m4v (which is recognized by the iPad/quicktime).  

DRAFT: http://tools.ietf.org/html/draft-pantos-http-live-streaming-10

Tested on iPad3
