### PR TITLE
Implement Fisher-Yates shuffle - it's fast and actually random

### DIFF
--- a/add-on/jplayer.playlist.js
+++ b/add-on/jplayer.playlist.js
@@ -449,9 +449,10 @@
 				$(this.cssSelector.playlist + " ul").slideUp(this.options.playlistOptions.shuffleTime, function() {
 					self.shuffled = shuffled;
 					if(shuffled) {
-						self.playlist.sort(function() {
-							return 0.5 - Math.random();
-						});
+						for (var tmp, cur, top=self.playlist.length; top--;){
+							cur = (Math.random() * (top + 1)) << 0;
+							tmp = self.playlist[cur]; self.playlist[cur] = self.playlist[top]; self.playlist[top] = tmp;
+						}
 					} else {
 						self._originalPlaylist();
 					}


### PR DESCRIPTION
Using the sort method tends to result in tracks towards the beginning or end
of the playlist having a 50% chance to not move at all. Fisher-Yates gives
good distribution across the whole playlist. Performance should be pretty
decent too.
