### PR TITLE
Add insert and replace methods

### DIFF
--- a/add-on/jplayer.playlist.js
+++ b/add-on/jplayer.playlist.js
@@ -387,6 +387,53 @@
 				return true;
 			}
 		},
+		insert: function(index, media, playNow) {
+			var self = this;
+
+			if(this.playlist.length == 0) {
+				return this.add(media, playNow)
+			} else if(index === undefined) {
+				return true;
+			}
+
+			index = (index < 0) ? this.original.length + index : index; // Negative index relates to end of array.
+			if(0 <= index && index < this.playlist.length) {
+				el = $(this._createListItem(media));
+				this.playlist[index]._element.before(el);
+				el.hide().slideDown(this.options.playlistOptions.addTime);
+				media._element = el;
+				this._updateControls();
+
+				if(this.shuffled) {
+					var item = this.playlist[index];
+					$.each(this.original, function(i) {
+						if(self.original[i] === item) {
+							self.original.splice(i, 0, media);
+							return false; // Exit $.each
+						}
+					});
+					this.playlist.splice(index, 0, media);
+				} else {
+					this.original.splice(index, 0, media);
+					this.playlist.splice(index, 0, media);
+				}
+			}
+			return true;
+		},
+		replace: function(index, media, playNow) {
+			if(index === undefined) {
+				return true;
+			} else if (!this.insert(index, media, playNow)) {
+				return false;
+			}
+			removed = this.remove(index + 1);
+			if(removed) {
+				if(this.current == index) {
+					this.select(index);
+				}
+			}
+			return removed;
+		},
 		select: function(index) {
 			index = (index < 0) ? this.original.length + index : index; // Negative index relates to end of array.
 			if(0 <= index && index < this.playlist.length) {


### PR DESCRIPTION
Both methods take the arguments `index`, `media`, `playNow`.  The
`insert` method adds the `media` to the playlist immediately preceeding
the specified `index`.  The `replace` method `insert`s the `media`, then
`remove`s the playlist entry that was previously at that position.

This PR depends on #151, and probably obsoletes #102.

I though I'd get this PR into the queue even though #151 has not been
reviewed yet - I'll rebase this if #151 is merged.
