### PR TITLE
Return good ratio in Flash players when file loaded but no total length

### DIFF
--- a/actionscript/happyworm/jPlayer/JplayerMp3.as
+++ b/actionscript/happyworm/jPlayer/JplayerMp3.as
@@ -337,6 +337,8 @@ package happyworm.jPlayer {
 		public function getLoadRatio():Number {
 			if((myStatus.isLoading || myStatus.isLoaded) && mySound.bytesTotal > 0) {
 				return mySound.bytesLoaded / mySound.bytesTotal;
+			} else if (myStatus.isLoaded && mySound.bytesLoaded > 0) {
+				return 1;
 			} else {
 				return 0;
 			}

--- a/actionscript/happyworm/jPlayer/JplayerMp4.as
+++ b/actionscript/happyworm/jPlayer/JplayerMp4.as
@@ -343,6 +343,8 @@ package happyworm.jPlayer {
 		public function getLoadRatio():Number {
 			if((myStatus.isLoading || myStatus.isLoaded) && myStream.bytesTotal > 0) {
 				return myStream.bytesLoaded / myStream.bytesTotal;
+			} else if (myStatus.isLoaded && myStream.bytesLoaded > 0) {
+				return 1;
 			} else {
 				return 0;
 			}

--- a/actionscript/happyworm/jPlayer/JplayerRtmp.as
+++ b/actionscript/happyworm/jPlayer/JplayerRtmp.as
@@ -871,10 +871,11 @@ package happyworm.jPlayer
 		return 1;
 		/*trace("LoadRatio:"+myStream.bytesLoaded, myStream.bytesTotal);
 		if((myStatus.isLoading || myStatus.isLoaded) && myStream.bytesTotal > 0) {
-		
-		return myStream.bytesLoaded / myStream.bytesTotal;
+			return myStream.bytesLoaded / myStream.bytesTotal;
+		} else if (myStatus.isLoaded && myStream.bytesLoaded > 0) {
+			return 1;
 		} else {
-		return 0;
+			return 0;
 		}
 		*/
 


### PR DESCRIPTION
When the played file's web server doesn't provide content-length header (when transcoding for example), flash player is able to seek on the file once completely loaded but the seek bar isn't visible. This fix it.
