### PR TITLE
Chrome on android phone supports full screen

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -546,7 +546,7 @@
 				iphone: /iphone/,
 				ipod: /ipod/,
 				android_pad: /android [0-3]\.(?!.*?mobile)/,
-				android_phone: /android.*?mobile/,
+				android_phone: /(?=.*android)(?!.*chrome)(?=.*mobile)/,
 				blackberry: /blackberry/,
 				windows_ce: /windows ce/,
 				iemobile: /iemobile/,


### PR DESCRIPTION
The Chrome browser on android mobile [has supported full screen since it's release](http://www.brighthand.com/default.asp?newsID=20141). This change updates that noFullWindow regex so that it returns false if the phone is running Chrome.
