### PR TITLE
Add support for native fullscreen api in Internet explorer.

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -353,13 +353,22 @@
 						'webkitExitFullscreen',
 						'',
 						''
+					],
+					ms: [
+						'',
+						'msFullscreenElement',
+						'msRequestFullscreen',
+						'msExitFullscreen',
+						'MSFullscreenChange',
+						'MSFullscreenError'
 					]
 				},
 				specOrder = [
 					'w3c',
 					'moz',
 					'webkit',
-					'webkitVideo'
+					'webkitVideo',
+					'ms'
 				],
 				fs, i, il;
 
@@ -368,7 +377,8 @@
 					w3c: !!d[spec.w3c[0]],
 					moz: !!d[spec.moz[0]],
 					webkit: typeof d[spec.webkit[3]] === 'function',
-					webkitVideo: typeof v[spec.webkitVideo[2]] === 'function'
+					webkitVideo: typeof v[spec.webkitVideo[2]] === 'function',
+					ms: typeof v[spec.ms[2]] === 'function'
 				},
 				used: {}
 			};


### PR DESCRIPTION
IE11 has native [fullscreen support](http://caniuse.com/fullscreen) which this change adds support for. This allows you to get a full size player when embedding in an iframe, which the existing fullWindow did not have the ability to do.
