### PR TITLE
Solution format support resolution

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -997,8 +997,14 @@
 			this.html.support = {};
 			this.flash.support = {};
 			$.each(this.formats, function(priority, format) {
-				self.html.support[format] = self.html.canPlay[format] && self.html.desired;
-				self.flash.support[format] = self.flash.canPlay[format] && self.flash.desired;
+				var formatSupported = false;
+
+				$.each(self.solutions, function(solutionPriority, solution) {
+					if (!formatSupported && self[solution].canPlay[format]) {
+						self[solution].support[format] = true;
+						formatSupported = true;
+					}
+				});
 			});
 			// If jPlayer is supporting any format in a solution, then the solution is used.
 			this.html.used = false;


### PR DESCRIPTION
If `solution` is `"html, flash"` and supplied contains e.g. `flv`, the video won't be played because `html` will be `desired` and no `solution` will support `flv`. This can occur if you use playlist with different formats (`mp4`, `flv`, `mp3`) and not all items in playlist have all formats.

With this fix the first solution that can play format is selected as supported.
