### PR TITLE
Add options for download links

### DIFF
--- a/add-on/jplayer.playlist.js
+++ b/add-on/jplayer.playlist.js
@@ -148,7 +148,8 @@
 				freeGroupClass: "jp-free-media",
 				freeItemClass: "jp-playlist-item-free",
 				removeItemClass: "jp-playlist-item-remove",
-				downloadPrefix: ''
+				downloadPrefix: '',
+				downloadForceRightClick: true
 			}
 		},
 		option: function(option, value) { // For changing playlist options only
@@ -280,11 +281,13 @@
 			});
 
 			// Create live handlers that disable free media links to force access via right click
-			$(this.cssSelector.playlist).off("click", "a." + this.options.playlistOptions.freeItemClass).on("click", "a." + this.options.playlistOptions.freeItemClass, function() {
-				$(this).parent().parent().find("." + self.options.playlistOptions.itemClass).click();
-				$(this).blur();
-				return false;
-			});
+			if(this.options.downloadForceRightClick) {
+				$(this.cssSelector.playlist).off("click", "a." + this.options.playlistOptions.freeItemClass).on("click", "a." + this.options.playlistOptions.freeItemClass, function() {
+					$(this).parent().parent().find("." + self.options.playlistOptions.itemClass).click();
+					$(this).blur();
+					return false;
+				});
+			}
 
 			// Create live handlers for the remove controls
 			$(this.cssSelector.playlist).off("click", "a." + this.options.playlistOptions.removeItemClass).on("click", "a." + this.options.playlistOptions.removeItemClass, function() {


### PR DESCRIPTION
This adds support for two new options for download links (_.jp-playlist-item-free_), namely a prefix that is added before the link (`downloadPrefix`) and the ability to disable the "force right click" handler (`downloadForceRightClick`).

I use this to redirect the links to a server-side script that changes a few headers to allow left-click download of files.
