### PR TITLE
Fixed MIME type of mp3 for #223

### DIFF
--- a/jquery.jplayer/jquery.jplayer.js
+++ b/jquery.jplayer/jquery.jplayer.js
@@ -702,7 +702,7 @@
 		// 'MPEG-4 support' : canPlayType('video/mp4; codecs="mp4v.20.8"')
 		format: { // Static Object
 			mp3: {
-				codec: 'audio/mpeg; codecs="mp3"',
+				codec: 'audio/mpeg',
 				flashCanPlay: true,
 				media: 'audio'
 			},


### PR DESCRIPTION
`(new Audio()).canPlayType('audio/mpeg')`
Works on Chrome 36.0.1985.125, Firefox 30.0 and IE11

References: [Chromium_issues_386073#c11](https://code.google.com/p/chromium/issues/detail?id=386073#c11), [RFC_3003](http://tools.ietf.org/html/rfc3003), [Video_type_parameters#MPEG](http://wiki.whatwg.org/wiki/Video_type_parameters#MPEG)
