### PR TITLE
Added code minifier using grunt as dependency

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,14 @@
+module.exports = function(grunt) {
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        uglify: {
+            build: {
+                src: 'jquery.jplayer/jquery.jplayer.js',
+                dest: 'jquery.jplayer/jquery.jplayer.min.js'
+            }
+        }
+    });
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.registerTask('default', ['uglify']);
+
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "video"
   ],
   "dependencies": {
-    "jquery": ">1.7.0"
+    "jquery": ">1.7.0",
+    "grunt": ">=0.4.1",
+    "grunt-contrib-uglify": ">=0.4.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
This may be totally unnecessary as part of the repo and I just did it in my cloned copy of the repo, so I could serve the minified version of jPlayer right away. 

The only reason I considered submitting a pull request was that in relation to [this thread](https://groups.google.com/forum/#!topic/jplayer/fJwtdOxJ8nA) where users were unsure how to make the change to the source code, I figured they might also be wondering how to minify the source and what to do next (I was anticipating that question on the board, actually). 

Anyway, if they have `npm` installed, they can just clone the repo, then do:

```
npm install
grunt uglify
```

On the plus side, it's an easy way to get people the minified code without having to minify it, and `grunt` can be used for other stuff.

The big problem, though, is that if users don't know how to minify js source _and_ they don't have `npm` installed, this won't be that useful.

Thus, I thought this might be helpful for inexperienced users cloning the repo, but feel free to reject this pull request if it doesn't fit in with jPlayer as a whole. 

Changes:
Added: gruntfile.js, which includes command to minify jplayer source
Edited: package.json to include 'grunt' and 'grunt-uglify' as dependencies.
