### PR TITLE
Add Aurora.js solution

### DIFF
--- a/src/javascript/jplayer/jquery.jplayer.js
+++ b/src/javascript/jplayer/jquery.jplayer.js
@@ -490,7 +490,7 @@
 		},
 		options: { // Instanced in $.jPlayer() constructor
 			swfPath: "js", // Path to jquery.jplayer.swf. Can be relative, absolute or server root relative.
-			solution: "html, flash", // Valid solutions: html, flash. Order defines priority. 1st is highest,
+			solution: "html, flash", // Valid solutions: html, flash, aurora. Order defines priority. 1st is highest,
 			supplied: "mp3", // Defines which formats jPlayer will try and support and the priority by the order. 1st is highest,
 			preload: 'metadata',  // HTML5 Spec values: none, metadata, auto.
 			volume: 0.8, // The volume. Number 0 to 1.
@@ -645,6 +645,7 @@
 			idPrefix: "jp", // Prefix for the ids of html elements created by jPlayer. For flash, this must not include characters: . - + * / \
 			noConflict: "jQuery",
 			emulateHtml: false, // Emulates the HTML5 Media element on the jPlayer element.
+			auroraFormats: 'flac, m4a, mp3, oga', // List of formats with loaded Aurora.js codecs
 			consoleAlerts: true, // Alerts are sent to the console.log() instead of alert().
 			errorAlerts: false,
 			warningAlerts: false
@@ -719,6 +720,7 @@
 		},
 		solution: { // Static Object: Defines the solutions built in jPlayer.
 			html: true,
+			aurora: true,
 			flash: true
 		},
 		// 'MPEG-4 support' : canPlayType('video/mp4; codecs="mp4v.20.8"')
@@ -849,6 +851,9 @@
 			this.html = {}; // In _init()'s this.desired code and setmedia(): Accessed via this[solution], where solution from this.solutions array.
 			this.html.audio = {};
 			this.html.video = {};
+			this.aurora = {}; // In _init()'s this.desired code and setmedia(): Accessed via this[solution], where solution from this.solutions array.
+			this.aurora.formats = [];
+			this.aurora.properties = [];
 			this.flash = {}; // In _init()'s this.desired code and setmedia(): Accessed via this[solution], where solution from this.solutions array.
 			
 			this.css = {};
@@ -889,6 +894,23 @@
 					});
 					if(!dupFound) {
 						self.solutions.push(solution);
+					}
+				}
+			});
+				
+			// Create Aurora.js formats array
+			$.each(this.options.auroraFormats.toLowerCase().split(","), function(index1, value1) {
+				var format = value1.replace(/^\s+|\s+$/g, ""); //trim
+				if(self.format[format]) { // Check format is valid.
+					var dupFound = false;
+					$.each(self.aurora.formats, function(index2, value2) { // Check for duplicates
+						if(format === value2) {
+							dupFound = true;
+							return false;
+						}
+					});
+					if(!dupFound) {
+						self.aurora.formats.push(format);
 					}
 				}
 			});
@@ -998,12 +1020,15 @@
 			this.flash.available = this._checkForFlash(10.1);
 
 			this.html.canPlay = {};
+			this.aurora.canPlay = {};
 			this.flash.canPlay = {};
 			$.each(this.formats, function(priority, format) {
 				self.html.canPlay[format] = self.html[self.format[format].media].available && "" !== self.htmlElement[self.format[format].media].canPlayType(self.format[format].codec);
+				self.aurora.canPlay[format] = (self.aurora.formats.indexOf(format) > -1);
 				self.flash.canPlay[format] = self.format[format].flashCanPlay && self.flash.available;
 			});
 			this.html.desired = false;
+			this.aurora.desired = false;
 			this.flash.desired = false;
 			$.each(this.solutions, function(solutionPriority, solution) {
 				if(solutionPriority === 0) {
@@ -1025,13 +1050,16 @@
 			});
 			// This is what jPlayer will support, based on solution and supplied.
 			this.html.support = {};
+			this.aurora.support = {};
 			this.flash.support = {};
 			$.each(this.formats, function(priority, format) {
 				self.html.support[format] = self.html.canPlay[format] && self.html.desired;
+				self.aurora.support[format] = self.aurora.canPlay[format] && self.aurora.desired;
 				self.flash.support[format] = self.flash.canPlay[format] && self.flash.desired;
 			});
 			// If jPlayer is supporting any format in a solution, then the solution is used.
 			this.html.used = false;
+			this.aurora.used = false;
 			this.flash.used = false;
 			$.each(this.solutions, function(solutionPriority, solution) {
 				$.each(self.formats, function(formatPriority, format) {
@@ -1049,8 +1077,8 @@
 			// Set up the css selectors for the control and feedback entities.
 			this._cssSelectorAncestor(this.options.cssSelectorAncestor);
 			
-			// If neither html nor flash are being used by this browser, then media playback is not possible. Trigger an error event.
-			if(!(this.html.used || this.flash.used)) {
+			// If neither html nor aurora nor flash are being used by this browser, then media playback is not possible. Trigger an error event.
+			if(!(this.html.used || this.aurora.used || this.flash.used)) {
 				this._error( {
 					type: $.jPlayer.error.NO_SOLUTION, 
 					context: "{solution:'" + this.options.solution + "', supplied:'" + this.options.supplied + "'}",
@@ -1150,13 +1178,18 @@
 					});
 				}
 			}
+			
+			// Add the Aurora.js solution if being used.
+			if(this.aurora.used) {
+				// Aurora.js player need to be created for each media, see setMedia function.
+			}
 
 			// Create the bridge that emulates the HTML Media element on the jPlayer DIV
 			if( this.options.emulateHtml ) {
 				this._emulateHtmlBridge();
 			}
 
-			if(this.html.used && !this.flash.used) { // If only HTML, then emulate flash ready() call after 100ms.
+			if((this.html.used || this.aurora.used) && !this.flash.used) { // If only HTML, then emulate flash ready() call after 100ms.
 				setTimeout( function() {
 					self.internal.ready = true;
 					self.version.flash = "n/a";
@@ -1453,6 +1486,77 @@
 				}, false);
 			});
 		},
+		_addAuroraEventListeners : function(player, entity) {
+			var self = this;
+			//player.preload = this.options.preload;
+			//player.muted = this.options.muted;
+			player.volume = this.options.volume * 100;
+
+			// Create the event listeners
+			// Only want the active entity to affect jPlayer and bubble events.
+			// Using entity.gate so that object is referenced and gate property always current
+			
+			player.on("progress", function() {
+				if(entity.gate) {
+					if(self.internal.cmdsIgnored && this.readyState > 0) { // Detect iOS executed the command
+						self.internal.cmdsIgnored = false;
+					}
+					self._getAuroraStatus(player);
+					self._updateInterface();
+					self._trigger($.jPlayer.event.progress);
+					// Progress with song duration, we estimate timeupdate need to be triggered too.
+					if (player.duration > 0) {
+						self._trigger($.jPlayer.event.timeupdate);
+					}
+				}
+			}, false);
+			player.on("ready", function() {
+				if(entity.gate) {
+					self._trigger($.jPlayer.event.loadeddata);
+				}
+			}, false);
+			player.on("duration", function() {
+				if(entity.gate) {
+					self._getAuroraStatus(player);
+					self._updateInterface();
+					self._trigger($.jPlayer.event.durationchange);
+				}
+			}, false);
+			player.on("end", function() {
+				if(entity.gate) {
+					// Order of the next few commands are important. Change the time and then pause.
+					self._updateButtons(false);
+					self._getAuroraStatus(player, true);
+					self._updateInterface();
+					self._trigger($.jPlayer.event.ended);
+				}
+			}, false);
+			player.on("error", function() {
+				if(entity.gate) {
+					self._updateButtons(false);
+					self._seeked();
+					if(self.status.srcSet) { // Deals with case of clearMedia() causing an error event.
+						self.status.waitForLoad = true; // Allows the load operation to try again.
+						self.status.waitForPlay = true; // Reset since a play was captured.
+						if(self.status.video && !self.status.nativeVideoControls) {
+							self.internal.video.jq.css({'width':'0px', 'height':'0px'});
+						}
+						if(self._validString(self.status.media.poster) && !self.status.nativeVideoControls) {
+							self.internal.poster.jq.show();
+						}
+						if(self.css.jq.videoPlay.length) {
+							self.css.jq.videoPlay.show();
+						}
+						self._error( {
+							type: $.jPlayer.error.URL,
+							context: self.status.src, // this.src shows absolute urls. Want context to show the url given.
+							message: $.jPlayer.errorMsg.URL,
+							hint: $.jPlayer.errorHint.URL
+						});
+					}
+				}
+			}, false);
+		},
 		_getHtmlStatus: function(media, override) {
 			var ct = 0, cpa = 0, sp = 0, cpr = 0;
 
@@ -1493,6 +1597,39 @@
 			this.status.playbackRate = media.playbackRate;
 			this.status.ended = media.ended;
 		},
+		_getAuroraStatus: function(player, override) {
+			var ct = 0, cpa = 0, sp = 0, cpr = 0;
+
+			this.status.duration = player.duration / 1000;
+
+			ct = player.currentTime / 1000;
+			cpa = (this.status.duration > 0) ? 100 * ct / this.status.duration : 0;
+			if(player.buffered > 0) {
+				sp = (this.status.duration > 0) ? (player.buffered * this.status.duration) / this.status.duration : 100;
+				cpr = (this.status.duration > 0) ? ct / (player.buffered * this.status.duration) : 0;
+			} else {
+				sp = 100;
+				cpr = cpa;
+			}
+			
+			if(override) {
+				ct = 0;
+				cpr = 0;
+				cpa = 0;
+			}
+
+			this.status.seekPercent = sp;
+			this.status.currentPercentRelative = cpr;
+			this.status.currentPercentAbsolute = cpa;
+			this.status.currentTime = ct;
+
+			this.status.remaining = this.status.duration - this.status.currentTime;
+
+			this.status.readyState = 4; // status.readyState;
+			this.status.networkState = 0; // status.networkState;
+			this.status.playbackRate = 1; // status.playbackRate;
+			this.status.ended = false; // status.ended;
+		},
 		_resetStatus: function() {
 			this.status = $.extend({}, this.status, $.jPlayer.prototype.status); // Maintains the status properties that persist through a reset.
 		},
@@ -1503,6 +1640,7 @@
 			event.jPlayer.options = $.extend(true, {}, this.options); // Deep copy
 			event.jPlayer.status = $.extend(true, {}, this.status); // Deep copy
 			event.jPlayer.html = $.extend(true, {}, this.html); // Deep copy
+			event.jPlayer.aurora = $.extend(true, {}, this.aurora); // Deep copy
 			event.jPlayer.flash = $.extend(true, {}, this.flash); // Deep copy
 			if(error) {
 				event.jPlayer.error = $.extend({}, error);
@@ -1757,10 +1895,12 @@
 		_resetGate: function() {
 			this.html.audio.gate = false;
 			this.html.video.gate = false;
+			this.aurora.gate = false;
 			this.flash.gate = false;
 		},
 		_resetActive: function() {
 			this.html.active = false;
+			this.aurora.active = false;
 			this.flash.active = false;
 		},
 		_escapeHtml: function(s) {
@@ -1819,6 +1959,7 @@
 				$.each(self.solutions, function(solutionPriority, solution) {
 					if(self[solution].support[format] && self._validString(media[format])) { // Format supported in solution and url given for format.
 						var isHtml = solution === 'html';
+						var isAurora = solution === 'aurora';
 
 						if(isVideo) {
 							if(isHtml) {
@@ -1844,6 +1985,10 @@
 								if($.jPlayer.platform.android) {
 									self.androidFix.setMedia = true;
 								}
+							} else if(isAurora) {
+								self.aurora.gate = true;
+								self._aurora_setAudio(media);
+								self.aurora.active = true;
 							} else {
 								self.flash.gate = true;
 								self._flash_setAudio(media);
@@ -1914,6 +2059,8 @@
 
 			if(this.html.active) {
 				this._html_resetMedia();
+			} else if(this.aurora.active) {
+				this._aurora_resetMedia();
 			} else if(this.flash.active) {
 				this._flash_resetMedia();
 			}
@@ -1923,6 +2070,8 @@
 
 			if(this.html.active) {
 				this._html_clearMedia();
+			} else if(this.aurora.active) {
+				this._aurora_clearMedia();
 			} else if(this.flash.active) {
 				this._flash_clearMedia();
 			}
@@ -1934,6 +2083,8 @@
 			if(this.status.srcSet) {
 				if(this.html.active) {
 					this._html_load();
+				} else if(this.aurora.active) {
+					this._aurora_load();
 				} else if(this.flash.active) {
 					this._flash_load();
 				}
@@ -1956,6 +2107,8 @@
 					this.focus();
 					if(this.html.active) {
 						this._html_play(time);
+					} else if(this.aurora.active) {
+						this._aurora_play(time);
 					} else if(this.flash.active) {
 						this._flash_play(time);
 					}
@@ -1972,6 +2125,8 @@
 			if(this.status.srcSet) {
 				if(this.html.active) {
 					this._html_pause(time);
+				} else if(this.aurora.active) {
+					this._aurora_pause(time);
 				} else if(this.flash.active) {
 					this._flash_pause(time);
 				}
@@ -2010,6 +2165,8 @@
 			if(this.status.srcSet) {
 				if(this.html.active) {
 					this._html_pause(0);
+				} else if(this.aurora.active) {
+					this._aurora_pause(0);
 				} else if(this.flash.active) {
 					this._flash_pause(0);
 				}
@@ -2022,6 +2179,8 @@
 			if(this.status.srcSet) {
 				if(this.html.active) {
 					this._html_playHead(p);
+				} else if(this.aurora.active) {
+					this._aurora_playHead(p);
 				} else if(this.flash.active) {
 					this._flash_playHead(p);
 				}
@@ -2042,6 +2201,9 @@
 			this.options.muted = muted;
 			if(this.html.used) {
 				this._html_setProperty('muted', muted);
+			}
+			if(this.aurora.used) {
+				this._aurora_mute(muted);
 			}
 			if(this.flash.used) {
 				this._flash_mute(muted);
@@ -2104,6 +2266,9 @@
 
 			if(this.html.used) {
 				this._html_setProperty('volume', v);
+			}
+			if(this.aurora.used) {
+				this._aurora_volume(v);
 			}
 			if(this.flash.used) {
 				this._flash_volume(v);
@@ -2915,6 +3080,98 @@
 			if(this.html.video.available) {
 				this.htmlElement.video[property] = value;
 			}
+		},
+		_aurora_setAudio: function(media) {
+			var self = this;            
+			
+			// Always finds a format due to checks in setMedia()
+			$.each(this.formats, function(priority, format) {
+				if(self.aurora.support[format] && media[format]) {
+					self.status.src = media[format];
+					self.status.format[format] = true;
+					self.status.formatType = format;
+			
+					return false;
+				}
+			});
+			
+			this.aurora.player = new AV.Player.fromURL(this.status.src);
+			this._addAuroraEventListeners(this.aurora.player, this.aurora);
+
+			if(this.options.preload === 'auto') {
+				this._aurora_load();
+				this.status.waitForLoad = false;
+			}
+		},
+		_aurora_resetMedia: function() {
+			if (this.aurora.player) {
+				this.aurora.player.stop();
+			}
+		},
+		_aurora_clearMedia: function() {
+			// Nothing to clear.
+		},
+		_aurora_load: function() {
+			if(this.status.waitForLoad) {
+				this.status.waitForLoad = false;
+				this.aurora.player.preload();
+			}
+		},
+		_aurora_play: function(time) {
+			if (!this.status.waitForLoad) {
+				if (!isNaN(time)) {
+					this.aurora.player.seek(time);
+				}
+			}
+			if (!this.aurora.player.playing) {
+				this.aurora.player.play();
+			}
+			this.status.waitForLoad = false;
+			this._aurora_checkWaitForPlay();
+			
+			// No event from the player, update UI now.
+			this._updateButtons(true);
+			this._trigger($.jPlayer.event.play);
+		},
+		_aurora_pause: function(time) {
+			if (!isNaN(time)) {
+				this.aurora.player.seek(time * 1000);
+			}
+			this.aurora.player.pause();
+			
+			if(time > 0) { // Avoids a setMedia() followed by stop() or pause(0) hiding the video play button.
+				this._aurora_checkWaitForPlay();
+			}
+			
+			// No event from the player, update UI now.
+			this._updateButtons(false);
+			this._trigger($.jPlayer.event.pause);
+		},
+		_aurora_playHead: function(percent) {
+			if(this.aurora.player.duration > 0) {
+				this.aurora.player.seek(percent * this.aurora.player.duration / 100);
+			}
+				
+			if(!this.status.waitForLoad) {
+				this._aurora_checkWaitForPlay();
+			}
+		},
+		_aurora_checkWaitForPlay: function() {
+			if(this.status.waitForPlay) {
+				this.status.waitForPlay = false;
+			}
+		},
+		_aurora_volume: function(v) {
+			this.aurora.player.volume = v * 100;
+		},
+		_aurora_mute: function(m) {
+			if (m) {
+				this.aurora.properties['lastvolume'] = this.aurora.player.volume;
+				this.aurora.player.volume = 0;
+			} else {
+				this.aurora.player.volume = this.aurora.properties['lastvolume'];
+			}
+			this.aurora.properties['muted'] = m;
 		},
 		_flash_setAudio: function(media) {
 			var self = this;


### PR DESCRIPTION
This add [Aurora.js](https://github.com/audiocogs/aurora.js) solution to jPlayer, like are html / flash solutions.
I personally did this for the [Ampache](https://github.com/ampache/ampache) project to avoid server transcoding when it is only used because of browser compatibility issues.

To test it, get the branch and set the following jPlayer options:

``` javascript
solution: 'html, flash, aurora',
auroraFormats: 'flac, m4a, mp3, oga'
```

Then include Aurora.js scripts / decoders:

``` html
<script src="aurora.js"></script>
<script src="ogg.js"></script>
<script src="flac.js"></script>
<script src="opus.js"></script>
<script src="mp3.js"></script>
```

I added a new **auroraFormats** option because Aurora.js can be extended with new decoders and we cannot determine which decoder manage which format from the js api.
Aurora.js provides a limited set of events, I will attempt to pull request on Aurora.js to improve their api but better to talk here before ; if this has some interest.
