### PR TITLE
Fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
       "url": "http://www.opensource.org/licenses/MIT"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/happyworm/jPlayer.git"
-    }
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyworm/jPlayer.git"
+  },
   "github": "http://github.com/happyworm/jPlayer",
   "main": "jquery.jplayer/jquery.jplayer.js"
 }


### PR DESCRIPTION
I'm tired of "jplayer@2.7.1 'repositories' (plural) Not supported. Please pick one as the 'repository' field" message :)
