### PR TITLE
Do not use minified version for node/browserify package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "bugs": "https://github.com/happyworm/jPlayer/issues",
   "github": "http://github.com/happyworm/jPlayer",
-  "main": "js/jplayer/jquery.jplayer.min.js",
+  "main": "src/javascript/jplayer/jquery.jplayer.js",
   "files": [
     "js",
     "skin/blue.monday",


### PR DESCRIPTION
Browserify users don't want the minified version of a package. Minifying it is a part of their custom build process.
