### PR TITLE
Fix: gracefull solution not used (e.g fail use Aurora for FLAC)

### DIFF
--- a/src/javascript/jplayer/jquery.jplayer.js
+++ b/src/javascript/jplayer/jquery.jplayer.js
@@ -1046,7 +1046,7 @@
 							}
 						}
 					});
-					self[solution].desired = (self.require.audio && !audioCanPlay) || (self.require.video && !videoCanPlay);
+					self[solution].desired = (self.require.audio && audioCanPlay) || (self.require.video && videoCanPlay);
 				}
 			});
 			// This is what jPlayer will support, based on solution and supplied.


### PR DESCRIPTION
E.g fail use Aurora for FLAC if <audio> tag does not support this because solution (e.g Aurora) marked as {desired: false} and {support: false} when {canPlay: true} too.
## What i need:

setMedia MP3 _or_ OGA _or_ FLAC
jPlayer params {supplied:"mp3,oga,flac"}

If browser doesn't support format in html5 use aurora as solution
{solution: "aurora", auroraFormats:"flac"}
## And here is problem:

if {solution: "html,aurora", supplied:"mp3,oga,flac"}
mp3:  plays
oga:  plays
flac: fail

if {solution: "html,aurora", supplied:"flac"}
mp3:  fail
oga:  fail
flac: plays

if {solution: "aurora", supplied:"mp3,oga,flac"}
mp3:  fail
oga:  fail
flac: plays
## P.S

Please, check code around this place, i can't understand it. E.g

``` javascript
$.each(this.solutions, function(solutionPriority, solution) {
    if(solutionPriority === 0) { // Why first solution already desired?
        self[solution].desired = true;
    } else {
        var audioCanPlay = false;
        var videoCanPlay = false;
        $.each(self.formats, function(formatPriority, format) {
            if(self[self.solutions[0]].canPlay[format]) { // Why [0]? Maybe [solutionPriority]?
                if(self.format[format].media === 'video') {
                    videoCanPlay = true;
                } else {
                    audioCanPlay = true;
                }
            }
        });
        self[solution].desired = (self.require.audio && audioCanPlay) || (self.require.video && videoCanPlay);
    }
});
```
