### PR TITLE
fixing wrong X coordinate is some mobile browsers

### DIFF
--- a/src/javascript/jplayer/jquery.jplayer.js
+++ b/src/javascript/jplayer/jquery.jplayer.js
@@ -2443,7 +2443,7 @@
 				// Using $(e.currentTarget) to enable multiple seek bars
 				var $bar = $(e.currentTarget),
 					offset = $bar.offset(),
-					x = e.pageX - offset.left,
+					x = window.pageXOffset + e.pageX - offset.left,
 					w = $bar.width(),
 					p = 100 * x / w;
 				this.playHead(p);


### PR DESCRIPTION
I noticed that jplayer calculates wrong X tap coordinate when I'm using Google Chrome or Opera web browser on Android when page is zoomed.