### PR TITLE
Replace robloach with oomphinc composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "robloach/component-installer": "*"
+        "oomphinc/composer-installers-extender": "*"
     },
     "suggest": {
         "components/jquery": ">=1.7.2"


### PR DESCRIPTION
Depreciation for robloach has been a warning for a few months now. we are updating ampache but jplayer needs to update as well to get rid of the warning.